### PR TITLE
Add D support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -169,3 +169,6 @@
 	branch = master
 	update = none
 	ignore = dirty
+[submodule "repos/d"]
+	path = repos/d
+	url = https://github.com/CyberShadow/tree-sitter-d/

--- a/tree-sitter-langs.el
+++ b/tree-sitter-langs.el
@@ -103,6 +103,7 @@ See `tree-sitter-langs-repos'."
                 (c-mode          . c)
                 (csharp-mode     . c-sharp)
                 (c++-mode        . cpp)
+                (d-mode          . d)
                 (css-mode        . css)
                 (elm-mode        . elm)
                 (elixir-mode     . elixir)


### PR DESCRIPTION
I'm trying to add support for [the D programming language](https://dlang.org) via https://github.com/CyberShadow/tree-sitter-d. But when I then do

```sh
script/compile d
```

on this branch it fails as

```
script/compile: line 13: cd: $'/home/per/Work/tree-sitter-langs/script\n/home/per/Work/tree-sitter-langs/script/..': No such file or directory
[tree-sitter-langs] Processing d
Debugger entered--Lisp error: (error "Unknown language `d'")
  signal(error ("Unknown language `d'"))
  error("Unknown language `%s'" d)
  (if source (file-name-as-directory (concat (tree-sitter-langs--repos-dir) (symbol-name lang-symbol))) (error "Unknown language `%s'" lang-symbol))
  (let* ((source (tree-sitter-langs--source lang-symbol)) (dir (if source (file-name-as-directory (concat (tree-sitter-langs--repos-dir) (symbol-name lang-symbol))) (error "Unknown language `%s'" lang-symbol))) (sub-path (format "repos/%s" lang-symbol)) (status (tree-sitter-langs--repo-status lang-symbol)) (paths (plist-get source :paths)) (bin-dir (tree-sitter-langs--bin-dir)) (tree-sitter-langs--out (tree-sitter-langs--buffer (format "*tree-sitter-langs-compile %s*" lang-symbol)))) (let ((default-directory tree-sitter-langs-git-dir)) (cond ((eq status :uninitialized) (let nil (tree-sitter-langs--call "git" "submodule" "update" "--init" "--checkout" "--" sub-path))) ((eq status :modified) (let nil (if clean (progn (let ... ...) (tree-sitter-langs--call "git" "submodule" "update" "--init" "--checkout" "--force" "--" sub-path))))) ((eq status :conflicts) (let nil (error "Unresolved conflicts in %s" dir))) ((eq status :synchronized) 'nil) (t (let nil (error "Weird status from git-submodule '%s'" status))))) (let ((default-directory dir)) (if (member lang-symbol tree-sitter-langs--langs-with-deps) (progn (tree-sitter-langs--call "npm" "set" "progress=false") (condition-case err (tree-sitter-langs--call "npm" "install") ((debug error) (message "Failed to run 'npm install': %s" err) nil)))) (let ((--dolist-tail-- paths)) (while --dolist-tail-- (let ((path-spec (car --dolist-tail--))) (let* ((path ...) (lang-symbol ...) (default-directory ...)) (tree-sitter-langs--call "tree-sitter" "generate") (if (and ... ...) (tree-sitter-langs--call "g++" "-shared" "-fPIC" "-fno-exceptions" "-g" "-O2" "-static-libgcc" "-static-libstdc++" "-I" "src" "src/scanner.cc" "-xc" "src/parser.c" "-o" ...) (tree-sitter-langs--call "tree-sitter" "test"))) (setq --dolist-tail-- (cdr --dolist-tail--))))) (let ((default-directory bin-dir)) (let ((--dolist-tail-- (directory-files default-directory))) (while --dolist-tail-- (let ((file ...)) (if (and ... ...) (progn ...)) (setq --dolist-tail-- (cdr --dolist-tail--)))))) (if (eq system-type 'darwin) (progn (let ((default-directory bin-dir)) (let ((--dolist-tail-- ...)) (while --dolist-tail-- (let ... ... ...)))))) (if clean (progn (tree-sitter-langs--call "git" "reset" "--hard" "HEAD") (tree-sitter-langs--call "git" "clean" "-f")))))
  tree-sitter-langs-compile(d)
  eval((tree-sitter-langs-compile 'd) t)
  command-line-1(("--directory" "." "--load" "tree-sitter-langs-build" "--eval" "(tree-sitter-langs-compile 'd)"))
  command-line()
  normal-top-level()
```

. What's am I missing?

Have you made this work, @CyberShadow?