### PR TITLE
Fix CI issues caused by new LetsEncrypt root CA cert

### DIFF
--- a/.azure-pipelines/main.yml
+++ b/.azure-pipelines/main.yml
@@ -32,8 +32,13 @@ jobs:
     vmImage: $(IMAGE_NAME)
   strategy:
     matrix:
-      vs2017-win2016:
-        IMAGE_NAME: 'vs2017-win2016'
+      # XXX: Temporarily disabled due to outdated CA cert bundle. Maybe check
+      # https://docs.certifytheweb.com/docs/kb/kb-202109-letsencrypt/
+      # vs2017-win2016:
+      #   IMAGE_NAME: 'vs2017-win2016'
+      #   BUNDLE_TARGET: windows
+      windows-2019:
+        IMAGE_NAME: 'windows-2019'
         BUNDLE_TARGET: windows
       macos-10.14-emacs-27.1:
         IMAGE_NAME: 'macos-10.14'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,10 +47,17 @@ jobs:
         if: runner.os != 'Windows'
         with:
           version: ${{ matrix.emacs-version }}
-      - uses: jcs090218/setup-emacs-windows@v4
+      # Seems like the Emacs archive from GNU's FTP uses its own outdated bundle of CA certs, which
+      # wouldn't include the new LetsEncrypt's root CA cert, which is used by MELPA, among others.
+      # So we use mingw64's Emacs instead. TODO: Switch back whenever possible.
+      - name: Install Emacs (Windows)
         if: runner.os == 'Windows'
-        with:
-          version: ${{ matrix.emacs-version }}
+        run: |
+          $env:MSYS_PATH = "$env:CD\ci-tools\msys2"
+          choco install msys2 --params="/InstallDir:$env:MSYS_PATH /NoPath"
+          $env:PATH = "$env:MSYS_PATH\usr\bin;" + $env:PATH
+          pacman -S --noconfirm --needed mingw-w64-x86_64-emacs
+          echo "$env:MSYS_PATH\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf-8 -Append
 
       - run: .github/script/setup-cask
       - run: cask install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,10 +38,17 @@ jobs:
         if: runner.os != 'Windows'
         with:
           version: ${{ matrix.emacs-version }}
-      - uses: jcs090218/setup-emacs-windows@v4
+      # Seems like the Emacs archive from GNU's FTP uses its own outdated bundle of CA certs, which
+      # wouldn't include the new LetsEncrypt's root CA cert, which is used by MELPA, among others.
+      # So we use mingw64's Emacs instead. TODO: Switch back whenever possible.
+      - name: Install Emacs (Windows)
         if: runner.os == 'Windows'
-        with:
-          version: ${{ matrix.emacs-version }}
+        run: |
+          $env:MSYS_PATH = "$env:CD\ci-tools\msys2"
+          choco install msys2 --params="/InstallDir:$env:MSYS_PATH /NoPath"
+          $env:PATH = "$env:MSYS_PATH\usr\bin;" + $env:PATH
+          pacman -S --noconfirm --needed mingw-w64-x86_64-emacs
+          echo "$env:MSYS_PATH\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf-8 -Append
 
       - run: .github/script/setup-cask
       - run: cask install

--- a/.gitmodules
+++ b/.gitmodules
@@ -69,7 +69,7 @@
 	branch = master
 [submodule "repos/janet-simple"]
 	path = repos/janet-simple
-	url = https://codeberg.org/sogaiu/tree-sitter-janet-simple
+	url = https://github.com/sogaiu/tree-sitter-janet-simple
 	update = none
 	ignore = dirty
 	branch = master


### PR DESCRIPTION
LetsEncrypt's new root CA cert `ISRG Root X1` is not as widely accepted as it should be yet. Some examples:
- The Emacs 27.2 archive for Windows on FTP probably includes an outdated bundle of root CA certs. See also https://github.com/jcs090218/setup-emacs-windows/issues/156
- Several hosted runners on GitHub Actions and Azure Pipelines.

This PR adds a bunch of workarounds.
One of them is switching janet-simple's git url from codeberg.org to github.com, FYI @sogaiu.

References:
- https://docs.certifytheweb.com/docs/kb/kb-202109-letsencrypt/
- https://letsencrypt.org/docs/dst-root-ca-x3-expiration-september-2021/