### PR TITLE
Update Elixir grammar to official Elixir-lang repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -165,7 +165,7 @@
 	branch = master
 [submodule "repos/elixir"]
 	path = repos/elixir
-	url = https://github.com/ananthakumaran/tree-sitter-elixir
+	url = https://github.com/elixir-lang/tree-sitter-elixir
 	branch = master
 	update = none
 	ignore = dirty

--- a/.gitmodules
+++ b/.gitmodules
@@ -166,6 +166,6 @@
 [submodule "repos/elixir"]
 	path = repos/elixir
 	url = https://github.com/elixir-lang/tree-sitter-elixir
-	branch = master
+	branch = main
 	update = none
 	ignore = dirty


### PR DESCRIPTION
The current elixir submodule has been archived as the Elixir team has their own tree-sitter grammar. This PR just points at the new repo. I'm not so confident with submodules, so if there is anything else that needs to be done let me know. 

Also, I believe the Elisp just pulls in the `queries/highlights.scm` so this should just work?