### PR TITLE
js/ts | fix highlighting of template string embedded expressions

### DIFF
--- a/queries/javascript/highlights.scm
+++ b/queries/javascript/highlights.scm
@@ -75,21 +75,13 @@
  property: (property_identifier) @property)
 ((shorthand_property_identifier) @property.definition)
 
-;; Literals
 
-[(this) (super) (true) (false)] @variable.builtin
-
-(regex) @string.special
-(number) @number
-
-[(string) (template_string)] @string
-(comment) @comment
 
 ;; Punctuation
 
 (template_substitution
  "${" @punctuation.special
- (_) @embedded
+ (_)
  "}" @punctuation.special)
 
 [";"
@@ -172,3 +164,23 @@
 
 ;; Misc.
 (statement_identifier) @label
+
+
+;; Literals
+
+[(this) (super) (true) (false)] @variable.builtin
+
+(regex) @string.special
+(number) @number
+
+(string) @string
+(comment) @comment
+
+(template_substitution
+ "${"
+ (_) @embedded
+ "}")
+
+;; template strings need to be last in the file for embedded expressions
+;; to work properly
+(template_string) @string


### PR DESCRIPTION
Closes https://github.com/emacs-tree-sitter/elisp-tree-sitter/issues/187
