### PR TITLE
Add Elixir highlight query

### DIFF
--- a/queries/elixir/highlights.scm
+++ b/queries/elixir/highlights.scm
@@ -1,0 +1,199 @@
+; Reserved keywords
+
+["when" "and" "or" "not" "in" "fn" "do" "end" "catch" "rescue" "after" "else"] @keyword
+
+; Operators
+
+; * doc string
+(unary_operator
+  operator: "@" @comment.doc
+  operand: (call
+    target: (identifier) @comment.doc.__attribute__
+    (arguments
+      [
+        (string) @comment.doc
+        (charlist) @comment.doc
+        (sigil
+          quoted_start: _ @comment.doc
+          quoted_end: _ @comment.doc) @comment.doc
+        (boolean) @comment.doc
+      ]))
+  (#match? @comment.doc.__attribute__ "^(moduledoc|typedoc|doc)$"))
+
+; * module attribute
+(unary_operator
+  operator: "@" @attribute
+  operand: [
+    (identifier) @attribute
+    (call
+      target: (identifier) @attribute)
+    (boolean) @attribute
+    (nil) @attribute
+  ])
+
+; * capture operand
+(unary_operator
+  operator: "&"
+  operand: (integer) @operator)
+
+(operator_identifier) @operator
+
+(unary_operator
+  operator: _ @operator)
+
+(binary_operator
+  operator: _ @operator)
+
+(dot
+  operator: _ @operator)
+
+(stab_clause
+  operator: _ @operator)
+
+; Literals
+
+[
+  (boolean)
+  (nil)
+] @constant
+
+[
+  (integer)
+  (float)
+] @number
+
+(alias) @type
+
+(call
+  target: (dot
+    left: (atom) @type))
+
+(char) @constant
+
+; Quoted content
+
+(interpolation "#{" @punctuation.special "}" @punctuation.special) @embedded
+
+(escape_sequence) @string.escape
+
+[
+  (atom)
+  (quoted_atom)
+  (keyword)
+  (quoted_keyword)
+] @string.special.symbol
+
+[
+  (string)
+  (charlist)
+] @string
+
+; Note that we explicitly target sigil quoted start/end, so they are not overridden by delimiters
+
+(sigil
+  (sigil_name) @__name__
+  quoted_start: _ @string
+  quoted_end: _ @string
+  (#match? @__name__ "^[sS]$")) @string
+
+(sigil
+  (sigil_name) @__name__
+  quoted_start: _ @string.regex
+  quoted_end: _ @string.regex
+  (#match? @__name__ "^[rR]$")) @string.regex
+
+(sigil
+  (sigil_name) @__name__
+  quoted_start: _ @string.special
+  quoted_end: _ @string.special) @string.special
+
+; Calls
+
+; * definition keyword
+(call
+  target: (identifier) @keyword
+  (#match? @keyword "^(def|defdelegate|defexception|defguard|defguardp|defimpl|defmacro|defmacrop|defmodule|defn|defnp|defoverridable|defp|defprotocol|defstruct)$"))
+
+; * kernel or special forms keyword
+(call
+  target: (identifier) @keyword
+  (#match? @keyword "^(alias|case|cond|else|for|if|import|quote|raise|receive|require|reraise|super|throw|try|unless|unquote|unquote_splicing|use|with)$"))
+
+; * function call
+(call
+  target: [
+    ; local
+    (identifier) @function
+    ; remote
+    (dot
+      right: (identifier) @function)
+  ])
+
+; * just identifier in function definition
+(call
+  target: (identifier) @keyword
+  (arguments
+    [
+      (identifier) @function
+      (binary_operator
+        left: (identifier) @function
+        operator: "when")
+    ])
+  (#match? @keyword "^(def|defdelegate|defguard|defguardp|defmacro|defmacrop|defn|defnp|defp)$"))
+
+; * pipe into identifier (definition)
+(call
+  target: (identifier) @keyword
+  (arguments
+    (binary_operator
+      operator: "|>"
+      right: (identifier) @variable))
+  (#match? @keyword "^(def|defdelegate|defguard|defguardp|defmacro|defmacrop|defn|defnp|defp)$"))
+
+; * pipe into identifier (function call)
+(binary_operator
+  operator: "|>"
+  right: (identifier) @function)
+
+; Identifiers
+
+; * special
+(
+  (identifier) @constant.builtin
+  (#match? @constant.builtin "^(__MODULE__|__DIR__|__ENV__|__CALLER__|__STACKTRACE__)$")
+)
+
+; * unused
+(
+  (identifier) @comment.unused
+  (#match? @comment.unused "^_")
+)
+
+; * regular
+(identifier) @variable
+
+; Comment
+
+(comment) @comment
+
+; Punctuation
+
+[
+ "%"
+] @punctuation
+
+[
+ ","
+ ";"
+] @punctuation.delimiter
+
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+  "<<"
+  ">>"
+] @punctuation.bracket

--- a/queries/elixir/highlights.scm
+++ b/queries/elixir/highlights.scm
@@ -7,19 +7,19 @@
 
 ; * doc string
 (unary_operator
-  operator: "@" @comment.doc
+  operator: "@" @attribute
   operand: (call
-    target: (identifier) @comment.doc.__attribute__
+    target: (identifier) @doc.__attribute__
     (arguments
       [
-        (string) @comment.doc
-        (charlist) @comment.doc
+        (string) @doc
+        (charlist) @doc
         (sigil
-          quoted_start: _ @comment.doc
-          quoted_end: _ @comment.doc) @comment.doc
-        (boolean) @comment.doc
+          quoted_start: _ @doc
+          quoted_end: _ @doc) @doc
+        (boolean) @doc
       ]))
-  (#match? @comment.doc.__attribute__ "^(moduledoc|typedoc|doc)$"))
+  (#match? @doc.__attribute__ "^(moduledoc|typedoc|doc)$"))
 
 ; * module attribute
 (unary_operator

--- a/queries/elixir/highlights.scm
+++ b/queries/elixir/highlights.scm
@@ -123,27 +123,28 @@
   target: (identifier) @keyword
   (#match? @keyword "^(alias|case|cond|else|for|if|import|quote|raise|receive|require|reraise|super|throw|try|unless|unquote|unquote_splicing|use|with)$"))
 
-; * function call
-(call
-  target: [
-    ; local
-    (identifier) @function
-    ; remote
-    (dot
-      right: (identifier) @function.call)
-  ])
-
 ; * just identifier in function definition
 (call
   target: (identifier) @keyword
   (arguments
     [
-      (identifier) @function
+      (call target: (identifier) @function)
       (binary_operator
-        left: (identifier) @function
+        left: (call
+               target: (identifier) @function)
         operator: "when")
     ])
   (#match? @keyword "^(def|defdelegate|defguard|defguardp|defmacro|defmacrop|defn|defnp|defp)$"))
+
+; * function call
+(call
+  target: [
+    ; local
+    (identifier) @function.call
+    ; remote
+    (dot
+      right: (identifier) @function.call)
+  ])
 
 ; * pipe into identifier (definition)
 (call

--- a/queries/elixir/highlights.scm
+++ b/queries/elixir/highlights.scm
@@ -1,5 +1,6 @@
 ; Reserved keywords
 
+; TODO: handle not in
 ["when" "and" "or" "not" "in" "fn" "do" "end" "catch" "rescue" "after" "else"] @keyword
 
 ; Operators
@@ -72,7 +73,10 @@
 
 ; Quoted content
 
-(interpolation "#{" @punctuation.special "}" @punctuation.special) @embedded
+(interpolation
+ "#{" @punctuation.special
+ (_) @embedded
+ "}" @punctuation.special)
 
 (escape_sequence) @string.escape
 
@@ -126,7 +130,7 @@
     (identifier) @function
     ; remote
     (dot
-      right: (identifier) @function)
+      right: (identifier) @function.call)
   ])
 
 ; * just identifier in function definition
@@ -153,7 +157,7 @@
 ; * pipe into identifier (function call)
 (binary_operator
   operator: "|>"
-  right: (identifier) @function)
+  right: (identifier) @function.call)
 
 ; Identifiers
 
@@ -165,8 +169,8 @@
 
 ; * unused
 (
-  (identifier) @comment.unused
-  (#match? @comment.unused "^_")
+  (identifier) @comment
+  (#match? @comment "^_")
 )
 
 ; * regular

--- a/queries/elixir/highlights.scm
+++ b/queries/elixir/highlights.scm
@@ -3,6 +3,13 @@
 ; TODO: handle not in
 ["when" "and" "or" "not" "in" "fn" "do" "end" "catch" "rescue" "after" "else"] @keyword
 
+; Interpolation
+
+(interpolation
+ "#{" @punctuation.special
+ (_) @embedded
+ "}" @punctuation.special)
+
 ; Operators
 
 ; * doc string
@@ -72,11 +79,6 @@
 (char) @constant
 
 ; Quoted content
-
-(interpolation
- "#{" @punctuation.special
- (_) @embedded
- "}" @punctuation.special)
 
 (escape_sequence) @string.escape
 

--- a/queries/elixir/highlights.scm
+++ b/queries/elixir/highlights.scm
@@ -85,7 +85,7 @@
   (quoted_atom)
   (keyword)
   (quoted_keyword)
-] @string.special.symbol
+] @constant
 
 [
   (string)


### PR DESCRIPTION
These changes update tree-sitter-elixir to the latest commit and add syntax highlight query. The query copied from upstream repo plus some modification to make it work on this package.