### PR TITLE
Include left_assignment_list in ruby query

### DIFF
--- a/queries/ruby/highlights.scm
+++ b/queries/ruby/highlights.scm
@@ -108,6 +108,11 @@
         (identifier) @variable
         (instance_variable) @variable])
 
+(left_assignment_list
+ [(identifier) @variable
+  (instance_variable) @variable
+  (class_variable) @variable.special])
+
 [(class_variable)
  (instance_variable)
  ] @property


### PR DESCRIPTION
Hello! I wasn't sure if I should raise an issue, but the code for this change seemed simple enough, so here it is! Let me know if there's a more helpful way for me to raise this issue.

---

This treats assignment to a list of variables in the same was as regular
assignment. Prior to this change assignment to a list of identifiers
would be highlighted the same way as references to those identifiers.

Before this change:
<img width="568" alt="before_left_assignment_list_change" src="https://user-images.githubusercontent.com/8159720/145749444-00ef4f3c-f447-40a6-805b-61bd9adbf68b.png">

And after:
<img width="461" alt="after_left_assgnment_list_change" src="https://user-images.githubusercontent.com/8159720/145749550-aac8ee42-1b72-4bf8-829e-4ed7bc8ec0b6.png">
