### PR TITLE
Imenu

### DIFF
--- a/queries/python/imenu.scm
+++ b/queries/python/imenu.scm
@@ -1,0 +1,12 @@
+(class_definition name: (identifier) @Class)
+
+(class_definition
+ body: (block
+        [(function_definition name: (identifier) @Method)
+         (expression_statement
+          (assignment
+           left: [(identifier) @Field
+                  (pattern_list (identifier) @Field)]))]))
+
+(function_definition
+ name: (identifier) @Function)


### PR DESCRIPTION
Language oriented imenu support courtesy of `elisp-tree-sitter`.

Also includes a proof of concept python imenu pattern file (we may want to rename it to tags.scm to be consistent with what was already in the python repository, I'm not sure about that).

See also [elisp-tree-sitter#199](https://github.com/emacs-tree-sitter/elisp-tree-sitter/pull/199).