### PR TITLE
Highlight ruby block delimiters consistently

### DIFF
--- a/queries/ruby/highlights.scm
+++ b/queries/ruby/highlights.scm
@@ -40,6 +40,10 @@
  "while"
  ] @keyword
 
+;; Braces, when used to denote a block, have the same function as "do" and "end"
+;; and should be highlighted similarly.
+(block ["{" "}"] @keyword)
+
 ((identifier) @keyword
  (.match? @keyword "^(private|protected|public)$"))
 


### PR DESCRIPTION
There are two syntaxes for defining "blocks" in ruby. One is to use "do"
and "end" to mark the start and end of a block, the other is to use "{"
and "}". These are used almost identically and so they should be
highlighted in the same way.

Plus, braces are also used to denote a Hash literal. For example, `{ a:
1 }` is a Hash with a key of `:a` and a value of 1, while `{ :a }` is a
block that just yields `:a`. This change allows those two different use
cases to be visually distinguished.

---

Before this change, brace blocks were highlighted differently from `do...end` blocks and the same as `Hash`es:
<img width="186" alt="Screen Shot 2021-12-28 at 14 28 19" src="https://user-images.githubusercontent.com/8159720/147601637-d3d5d379-1ef3-4746-8b35-1a01f525e0f3.png">

After this change, the brace blocks are highlighted the same as `do...end` blocks and are distinguishable from `Hash`es:
<img width="192" alt="Screen Shot 2021-12-28 at 14 30 45" src="https://user-images.githubusercontent.com/8159720/147601761-a6a79231-87b9-41a0-9a86-13b70dc28bf7.png">
