### PR TITLE
Updated tree-sitter-langs--os

### DIFF
--- a/tree-sitter-langs-build.el
+++ b/tree-sitter-langs-build.el
@@ -253,7 +253,7 @@ infrequent (grammar-only changes). It is different from the version of
   "Return the grammar bundle file's name, with optional EXT.
 If VERSION and OS are not spcified, use the defaults of
 `tree-sitter-langs--bundle-version' and `tree-sitter-langs--os'."
-  (format "tree-sitter-grammars-%s-%s.tar%s"
+  (format "tree-sitter-grammars.%s.v%s.tar%s"
           (or os tree-sitter-langs--os)
           (or version tree-sitter-langs--bundle-version)
           (or ext "")))

--- a/tree-sitter-langs-build.el
+++ b/tree-sitter-langs-build.el
@@ -236,9 +236,10 @@ infrequent (grammar-only changes). It is different from the version of
 
 (defconst tree-sitter-langs--os
   (pcase system-type
-    ('darwin "macos")
-    ('gnu/linux "linux")
-    ('windows-nt "windows")
+    ((guard (and (eq system-type 'darwin) (string= (car (split-string system-configuration "-")) "aarch64"))) "aarch64-apple-darwin")
+    ('darwin "x86_64-apple-darwin")
+    ('gnu/linux "x86_64-unknown-linux-gnu")
+    ('windows-nt "x86_64-pc-windows-msvc")
     (_ (error "Unsupported system-type %s" system-type))))
 
 (defconst tree-sitter-langs--suffixes '(".dylib" ".dll" ".so")


### PR DESCRIPTION
I updated `tree-sitter-langs--os` to account for Apple M1/silicon systems. I also updated `tree-sitter-langs--os` to account for the new filename output format.

This fixes https://github.com/emacs-tree-sitter/tree-sitter-langs/issues/36