### PR TITLE
Bump C++ grammar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Updated `cpp` grammar and highlighting.
 
 ## 0.11.0 - 2022-01-29
 - Made `tree-sitter-langs-install-grammars` download platform-specific binaries (mainly for Apple Silicon).

--- a/queries/cpp/highlights.scm
+++ b/queries/cpp/highlights.scm
@@ -26,19 +26,18 @@
 ;; Functions
 
 (call_expression
- function: (scoped_identifier name: (_) @function.call))
+ function: (qualified_identifier name: (_) @function.call))
 
 (template_function
  name: [(identifier) @function.call
-        (scoped_identifier name: (_) @function.call)])
+        (qualified_identifier name: (_) @function.call)])
 
 (template_method
- name: [(field_identifier) @method.call
-        (scoped_field_identifier name: (_) @method.call)])
+ name: (field_identifier) @method.call)
 
 (function_declarator
  declarator: [(field_identifier) @function
-              (scoped_identifier name: (_) @function)])
+              (qualified_identifier name: (_) @function)])
 
 ;;; ----------------------------------------------------------------------------
 ;; Types


### PR DESCRIPTION
Hello!:)

**Reason for updating:** nested namespace definition support; the old grammar handles it miserably.
**Reason for modifying the highlighting config**: breaking changes in https://github.com/tree-sitter/tree-sitter-cpp/pull/133

**I did not test this thoroughly**; just viewed a .cpp file with `tree-sitter-hl-mode` and `tree-sittter-debug-mode` enabled and observed the lack of errors. `script/test cpp` fails with the message "Cannot open load file: No such file or directory, tree-sitter".