### PR TITLE
Local compilation of abritrary TS grammars

### DIFF
--- a/tree-sitter-langs-build.el
+++ b/tree-sitter-langs-build.el
@@ -93,7 +93,6 @@ If BUFFER is nil, `princ' is used to forward its stdout+stderr."
 In batch mode, return nil, so that stdout is used instead."
   (unless noninteractive
     (let ((buf (get-buffer-create name)))
-      (pop-to-buffer buf)
       (delete-region (point-min) (point-max))
       (redisplay)
       buf)))

--- a/tree-sitter-langs.el
+++ b/tree-sitter-langs.el
@@ -64,9 +64,12 @@
   (unless (bound-and-true-p tree-sitter-langs--testing)
     (tree-sitter-langs-install-grammars :skip-if-installed)))
 
-(defun tree-sitter-langs-ensure (lang-symbol)
+(defun tree-sitter-langs-ensure (lang-symbol &optional src-dir &rest compilation-args)
   "Return the language object identified by LANG-SYMBOL.
 If it cannot be loaded, this function tries to compile the grammar.
+
+If SRC-DIR is non-nil, the language will be compiled from the provided directory.
+COMPILATION-ARGS will provide additional args to `tree-sitter-langs--compile'.
 
 This function also tries to copy highlight query from the language repo, if it
 exists.
@@ -79,9 +82,11 @@ See `tree-sitter-langs-repos'."
          (display-warning 'tree-sitter-langs
                           (format "Could not load grammar for `%s', trying to compile it"
                                   lang-symbol))
-         (tree-sitter-langs-compile lang-symbol)
-         (tree-sitter-require lang-symbol)))
-    (tree-sitter-langs--copy-query lang-symbol)))
+         (if src-dir
+             (apply #'tree-sitter-langs--compile lang-symbol src-dir compilation-args)
+           (tree-sitter-langs-compile lang-symbol))
+         (tree-sitter-require lang-symbol)
+         (tree-sitter-langs--copy-query lang-symbol src-dir)))))
 
 ;;;###autoload
 (defun tree-sitter-langs--init-load-path (&rest _args)


### PR DESCRIPTION
I wanted to get the ball rolling on abritrary grammar installation, so here's my attempt at it. Let me know if this fits in with your goals for TS langs, and what we can change if not!

This PR adds the following:

- Splits the compilation logic in `tree-sitter-langs-compile` from the submodule handling.
- Allows abritary directories to be specified in `tree-sitter-langs-ensure`.

This will allow users to be able to use grammars that aren't in TS langs, or compile versions that are more recent than what is in TS langs.

A next step I'd like to see is automatic installation from a git repo instead of cloning manually, but out of scope of this PR.