### PR TITLE
Map terraform-mode to the hcl grammer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Map `terraform-mode` to the `hcl` grammer.
+
 ## 0.11.6 - 2022-03-28
 - Updated `bash` grammar.
 

--- a/tree-sitter-langs.el
+++ b/tree-sitter-langs.el
@@ -132,6 +132,7 @@ See `tree-sitter-langs-repos'."
                 (rustic-mode     . rust)
                 (scala-mode      . scala)
                 (swift-mode      . swift)
+                (terraform-mode  . hcl)
                 (tuareg-mode     . ocaml)
                 (typescript-mode . typescript)
                 (zig-mode        . zig))))


### PR DESCRIPTION
Just maps `terraform-mode` to `hcl` in major mode mappings.