### PR TITLE
Update bash grammar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Updated `bash` grammar.
 
 ## 0.11.4 - 2022-03-19
 


### PR DESCRIPTION
Updated bash grammar to latest. Mainly because of [handling words containing bare '#'](https://github.com/tree-sitter/tree-sitter-bash/commit/4094e3a0405aabb1314c0c41f29e38e70af86fa5)