### PR TITLE
Add verilog to `tree-sitter-major-mode-language-alist`

### DIFF
--- a/tree-sitter-langs.el
+++ b/tree-sitter-langs.el
@@ -134,6 +134,7 @@ See `tree-sitter-langs-repos'."
                 (swift-mode      . swift)
                 (tuareg-mode     . ocaml)
                 (typescript-mode . typescript)
+                (verilog-mode    . verilog)
                 (zig-mode        . zig))))
     (cl-pushnew entry tree-sitter-major-mode-language-alist
                 :key #'car))


### PR DESCRIPTION
Verilog was added to repos, but was not added to `tree-sitter-major-mode-language-alist` in https://github.com/emacs-tree-sitter/tree-sitter-langs/pull/67 . 