### PR TITLE
Add FreeBSD support

### DIFF
--- a/tree-sitter-langs-build.el
+++ b/tree-sitter-langs-build.el
@@ -238,6 +238,7 @@ infrequent (grammar-only changes). It is different from the version of
   (pcase system-type
     ('darwin "macos")
     ('gnu/linux "linux")
+    ('berkeley-unix "freebsd")
     ('windows-nt "windows")
     (_ (error "Unsupported system-type %s" system-type))))
 
@@ -261,6 +262,7 @@ If VERSION and OS are not spcified, use the defaults of
               (pcase os
                 ("windows" "x86_64-pc-windows-msvc")
                 ("linux" "x86_64-unknown-linux-gnu")
+                ("freebsd" "x86_64-unknown-freebsd")
                 ("macos" (if (string-prefix-p "aarch64" system-configuration)
                              "aarch64-apple-darwin"
                            "x86_64-apple-darwin")))
@@ -365,6 +367,26 @@ from the current state of the grammar repo, without cleanup."
                       "src/parser.c"
                       "-o" (format "%sbin/%s.so" tree-sitter-langs-grammar-dir lang-symbol)
                       "-target" target))))
+           ((memq system-type '(berkeley-unix))
+            (cond
+             ((file-exists-p "src/scanner.cc")
+              (tree-sitter-langs--call
+               "c++" "-shared" "-fPIC" "-fno-exceptions" "-g" "-O2"
+               "-I" "src"
+               "src/scanner.cc" "-xc" "src/parser.c"
+               "-o" (format "%sbin/%s.so" tree-sitter-langs-grammar-dir lang-symbol)))
+             ((file-exists-p "src/scanner.c")
+              (tree-sitter-langs--call
+               "cc" "-shared" "-fPIC" "-g" "-O2"
+               "-I" "src"
+               "src/scanner.c" "src/parser.c"
+               "-o" (format "%sbin/%s.so" tree-sitter-langs-grammar-dir lang-symbol)))
+             (:default
+              (tree-sitter-langs--call
+               "cc" "-shared" "-fPIC" "-g" "-O2"
+               "-I" "src"
+               "src/parser.c"
+               "-o" (format "%sbin/%s.so" tree-sitter-langs-grammar-dir lang-symbol)))))
            (:default (tree-sitter-langs--call "tree-sitter" "test")))))
       ;; Replace underscores with hyphens. Example: c_sharp.
       (let ((default-directory bin-dir))


### PR DESCRIPTION
Currently, to run on FreeBSD you need to:

install cask, npm and cargo.

launch:
cargo install tree-sitter-cli

For npm, as the tgz doesn't exist for the moment you have to create a node_modules/tree-sitter-cli directory and copy the cli.js, dsl.d.ts, install.js, package.json, LICENSE files from the official tree-sitter/cli/npm/tree-sitter repository and also tree-sitter from the directory where cargo installed the binary

Of course you have to add ('berkeley-unix (list ".so")) in elisp-tree-sitter/lisp/tree-sitter-load.el to be able to load the .so

and that's it

If the FreeBSD build becomes integrated by default, all the prerequisites become superfluous