### PR TITLE
Use more maintained HCL language definition

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -157,12 +157,6 @@
 	update = none
 	ignore = dirty
 	branch = master
-[submodule "repos/hcl"]
-	path = repos/hcl
-	url = https://github.com/mitchellh/tree-sitter-hcl.git
-	update = none
-	ignore = dirty
-	branch = master
 [submodule "repos/elixir"]
 	path = repos/elixir
 	url = https://github.com/elixir-lang/tree-sitter-elixir

--- a/.gitmodules
+++ b/.gitmodules
@@ -157,6 +157,12 @@
 	update = none
 	ignore = dirty
 	branch = master
+[submodule "repos/hcl"]
+	path = repos/hcl
+	url = git@github.com:MichaHoffmann/tree-sitter-hcl.git
+	branch = main
+	update = none
+	ignore = dirty
 [submodule "repos/elixir"]
 	path = repos/elixir
 	url = https://github.com/elixir-lang/tree-sitter-elixir


### PR DESCRIPTION
The repo https://github.com/MichaHoffmann/tree-sitter-hcl is getting more regular updates than the currently-included hcl definitions. It also appears to correctly highlight variable interpolation in strings, unlike the existing one.

That said, I'm not sure how to verify that this works correctly -- I tried running `script/compile` and cp'ing the bin/hcl.dylib into my emacs-local tree-sitter-langs bin directory, but that doesn't work. I get a this error message when opening a file: `tree-sitter-after-on-hook: (tsc-query-invalid-node-type "one_line_block" (9 . 1) 124)`. 

Let me know if there's something better I should do to test/verify, or if this is just a no-go for now -- I tried resetting to v0.6.0, before the repo upgraded to tree-sitter 0.20.x, but got the same error.