### PR TITLE
Improve HCL support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -159,7 +159,7 @@
 	branch = master
 [submodule "repos/hcl"]
 	path = repos/hcl
-	url = https://github.com/mitchellh/tree-sitter-hcl.git
+	url = https://github.com/MichaHoffmann/tree-sitter-hcl
 	update = none
 	ignore = dirty
 	branch = master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased
+- Used a different `hcl` grammar.
+- Added support for mode-specific highlighting patterns.
+- Added highlighting patterns for `terraform-mode`.
 
 ## 0.11.6 - 2022-03-28
 - Updated `bash` grammar.

--- a/README.org
+++ b/README.org
@@ -19,7 +19,7 @@ For each supported language, this package provides:
 ** Highlighting Queries
 # *Note*: Highlighting styles are a mattter of taste.
 
-Highlighting query patterns for a language are in the file ~queries/{lang}/highlights.scm~. Most of them are *intentionally different* from those from upstream repositories, which are more geared towards /GitHub's use cases/. We try to be more consistent with /Emacs's existing conventions/. (For some languages, this is WIP, so their patterns may look similar to upstream's.)
+Highlighting query patterns for a language are in the file ~queries/<lang>/highlights.scm~. Most of them are *intentionally different* from those from upstream repositories, which are more geared towards /GitHub's use cases/. We try to be more consistent with /Emacs's existing conventions/. (For some languages, this is WIP, so their patterns may look similar to upstream's.)
 
 In general, try to follow what the docstrings of ~tree-sitter-hl-face:~ faces say. Most importantly:
 - Definitions and uses should be differentiated:
@@ -29,6 +29,9 @@ In general, try to follow what the docstrings of ~tree-sitter-hl-face:~ faces sa
 - ~@variable~ and ~@variable.parameter~ should be applied only to declarations/definitions/bindings/mutations (/writes/), not usage (/reads/).
 - Special faces should have high priority (placed earlier in the pattern list): ~@function.macro~, ~@type.builtin~, ~@variable.special~.
 - Patterns whose internals may be highlighted should have low priority (placed towards the end). Example: strings with interpolation.
+
+*** Mode-specific highlighting
+Some languages are associated with multiple major modes. Mode-specific highlighting patterns are provided by the files ~queries/<lang>/highlights.<major-mode>.scm~. These are combined with the base highlighting patterns in ~queries/<lang>/highlights.scm~, but have higher precedence.
 
 ** Building Grammars from Source
 Note: If you also plan to work on [[https://github.com/emacs-tree-sitter/elisp-tree-sitter#building-grammars-from-source][elisp-tree-sitter]], it might be more convenient to work with this repository as a submodule.

--- a/queries/hcl/highlights.scm
+++ b/queries/hcl/highlights.scm
@@ -1,36 +1,48 @@
-[
-  "for"
-] @keyword
+("for" @keyword (identifier) @variable)
 
+;; (attribute (identifier) @variable)
+;; (object_elem key: (_) @variable)
 (attribute (identifier) @property)
-(object_elem (identifier) @property)
+(object_elem key: (_) @property)
+
+(get_attr (identifier) @property)
 
 (block (identifier) @type)
-(one_line_block (identifier) @type)
+;; (one_line_block (identifier) @type)
 
-(function_call (identifier) @function)
-
-[
-  (string_literal)
-  (quoted_template)
-  (heredoc)
-] @string
-
-(numeric_literal) @number
+(function_call (identifier) @function.call)
 
 [
-  (true)
-  (false)
-  (null)
-] @constant.builtin
+ ;; (string_lit)
+ (quoted_template_start)
+ (quoted_template_end)
+ (template_literal)
+ ;; (heredoc)
+ ] @string
+
+(numeric_lit) @number
+
+[(bool_lit)
+ (null_lit)
+ ] @constant.builtin
 
 (comment) @comment
 
-[
-  "("
-  ")"
-  "["
-  "]"
-  "{"
-  "}"
-]  @punctuation.bracket
+["("
+ ")"
+ "["
+ "]"
+ "{"
+ "}"
+ ]  @punctuation.bracket
+
+["&&" "?" ":" "!=" "==" "=>"] @operator
+
+["if" "in"] @keyword
+
+;; "." @punctuation.special
+
+(template_interpolation
+ (template_interpolation_start) @punctuation.special
+ (expression) @embedded
+ (template_interpolation_end) @punctuation.special)

--- a/queries/hcl/highlights.terraform-mode.scm
+++ b/queries/hcl/highlights.terraform-mode.scm
@@ -1,0 +1,73 @@
+;; data.aws_iam_policy_document.cluster_assume_role_policy.json
+(expression
+ ((variable_expr (identifier)) @keyword
+  (.eq? @keyword "data"))
+ . (get_attr (identifier) @type)
+ . (get_attr (identifier) @function.call)
+ . (get_attr (identifier) @property)?
+ )
+
+;; module.path
+((expression
+  ((variable_expr (identifier)) @keyword
+   (.eq? @keyword "module"))
+  . (get_attr) @type
+  ))
+
+((expression
+  ((variable_expr (identifier)) @keyword
+   (.match? @keyword "^(var|local|count|each|path)$"))
+  . (get_attr)? @property
+  ))
+
+;; aws_iam_role.shared-sagemaker-execution.name
+(expression
+ (variable_expr (identifier)) @type
+ . (get_attr) @function.call
+ . (get_attr)? @property
+ .)
+
+;; TODO: Highlight `content'.
+((block (identifier) @keyword
+        [(string_lit (template_literal) @variable)])
+ (.eq? @keyword "dynamic"))
+
+;; ((block (identifier) @keyword
+;;         [(string_lit (template_literal) @variable)]
+;;         (body ((attribute (identifier) @keyword)
+;;                (.eq? @keyword "for_each"))))
+;;  (.eq? @keyword "dynamic"))
+
+((block (identifier) @keyword
+        . [(string_lit (template_literal) @function)
+           (identifier) @function])
+ (.eq? @keyword "output"))
+
+((block (identifier) @keyword
+        [(string_lit (template_literal) @variable.special)
+         (identifier) @variable.special])
+ (.eq? @keyword "variable"))
+
+((block (identifier) @keyword
+        [(string_lit (template_literal) @type)
+         (identifier) @type])
+ (.eq? @keyword "module"))
+
+;; resource "aws_launch_template" "default"
+(block (identifier)
+       [(string_lit (template_literal) @type)
+        (identifier) @type]
+       . [(string_lit (template_literal) @function)
+          (identifier) @function]
+       . (block_start))
+
+((block (identifier) @keyword)
+ (.match? @keyword "(resource|data|output|locals|lifecycle)"))
+
+((attribute (identifier) @keyword)
+ (.match? @keyword "^(count|depends_on|for_each)$"))
+
+(attribute (identifier) @variable)
+(object_elem key: (_) @variable)
+
+(block (identifier) @label . (block_start))

--- a/queries/hcl/highlights.terraform-mode.scm
+++ b/queries/hcl/highlights.terraform-mode.scm
@@ -29,7 +29,9 @@
 
 ;; TODO: Highlight `content'.
 ((block (identifier) @keyword
-        [(string_lit (template_literal) @variable)])
+        [(string_lit (quoted_template_start) @noise
+                     (template_literal) @variable
+                     (quoted_template_end) @noise)])
  (.eq? @keyword "dynamic"))
 
 ;; ((block (identifier) @keyword
@@ -39,25 +41,35 @@
 ;;  (.eq? @keyword "dynamic"))
 
 ((block (identifier) @keyword
-        . [(string_lit (template_literal) @function)
+        . [(string_lit (quoted_template_start) @noise
+                       (template_literal) @function
+                       (quoted_template_end) @noise)
            (identifier) @function])
  (.eq? @keyword "output"))
 
 ((block (identifier) @keyword
-        [(string_lit (template_literal) @variable.special)
+        [(string_lit (quoted_template_start) @noise
+                     (template_literal) @variable.special
+                     (quoted_template_end) @noise)
          (identifier) @variable.special])
  (.eq? @keyword "variable"))
 
 ((block (identifier) @keyword
-        [(string_lit (template_literal) @type)
+        [(string_lit (quoted_template_start) @noise
+                     (template_literal) @type
+                     (quoted_template_end) @noise)
          (identifier) @type])
  (.eq? @keyword "module"))
 
 ;; resource "aws_launch_template" "default"
 (block (identifier)
-       [(string_lit (template_literal) @type)
+       [(string_lit (quoted_template_start) @noise
+                    (template_literal) @type
+                    (quoted_template_end) @noise)
         (identifier) @type]
-       . [(string_lit (template_literal) @function)
+       . [(string_lit (quoted_template_start) @noise
+                      (template_literal) @function
+                      (quoted_template_end) @noise)
           (identifier) @function]
        . (block_start))
 


### PR DESCRIPTION
- Switch to https://github.com/MichaHoffmann/tree-sitter-hcl.
- Add mode-specific highlighting patterns for `terraform-mode`.

Subsumes #85 and #97.