### PR TITLE
Add the 'goto' keyword in C

### DIFF
--- a/queries/c/highlights.scm
+++ b/queries/c/highlights.scm
@@ -8,6 +8,7 @@
  "enum"
  "extern"
  "for"
+ "goto"
  "if"
  "inline"
  "return"


### PR DESCRIPTION
Super simple PR, just added the `goto` keyword to the keyword array in the C language highlight.scm queries file.