### PR TITLE
Bump java grammar

### DIFF
--- a/queries/java/highlights.scm
+++ b/queries/java/highlights.scm
@@ -57,7 +57,8 @@
 (false) @constant.builtin
 (null_literal) @constant.builtin
 
-(comment) @comment
+(line_comment) @comment
+(block_comment) @comment
 
 ; Keywords
 


### PR DESCRIPTION
Bumping java grammar to latest primarily for https://github.com/tree-sitter/tree-sitter-java/commit/a24ae7d16de3517bff243a87d087d0b4877a65c5

ref: https://github.com/meain/evil-textobj-tree-sitter/issues/54