### PR TITLE
Fix agda-mode => agda2-mode

### DIFF
--- a/tree-sitter-langs.el
+++ b/tree-sitter-langs.el
@@ -98,7 +98,7 @@ See `tree-sitter-langs-repos'."
   "Link known major modes to languages provided by the bundle."
   (dolist
       (entry (reverse
-              '((agda-mode       . agda)
+              '((agda2-mode      . agda)
                 (sh-mode         . bash)
                 (c-mode          . c)
                 (caml-mode       . ocaml)


### PR DESCRIPTION
The mode is called `agda2-mode` (see https://agda.readthedocs.io/en/latest/tools/emacs-mode.html).