### PR TITLE
Add syntax highlighting for YAML

### DIFF
--- a/queries/yaml/highlights.scm
+++ b/queries/yaml/highlights.scm
@@ -1,0 +1,16 @@
+[(double_quote_scalar) (single_quote_scalar) (block_scalar)] @string
+
+[(tag) (tag_handle)] @type
+
+(boolean_scalar) @constant
+
+[(float_scalar) (integer_scalar)] @number
+
+(block_mapping_pair . (flow_node) @variable)
+
+[(anchor) (alias)] @function
+
+(comment) @comment
+["---" "..."] @comment
+
+["{" "}" "[" "]"] @punctuation.bracket


### PR DESCRIPTION
The highlighting queries use capture names that correspond to yaml-mode's font-lock faces. The result is almost identical, some small differences exist due to the way the Tree-sitter parser for YAML is implemented. For example, `block_scalar` includes the block scalar header (block style indicator, block chomping indicator) which means that the block scalar header is highlighted with the same face as the actual block scalar (i.e. as a string), whereas in plain yaml-mode the block scalar header does not have a font-lock face at all.

Fixes #21 