### PR TITLE
feat(highlight/go): mark built-in functions as @function.builtin

### DIFF
--- a/queries/go/highlights.scm
+++ b/queries/go/highlights.scm
@@ -1,6 +1,10 @@
 ; Function calls
 
 (call_expression
+  function: (identifier) @function.builtin
+  (.match? @function.builtin "^(append|cap|close|complex|copy|delete|imag|len|make|new|panic|print|println|real|recover)$"))
+
+(call_expression
   function: (identifier) @function.call)
 
 (call_expression


### PR DESCRIPTION
Based on my [PR](https://github.com/tree-sitter/tree-sitter-go/pull/96) against [tree-sitter-go](https://github.com/tree-sitter/tree-sitter-go).

I have been using this query since March 10th in my own Emacs [config](https://github.com/jimeh/.emacs.d/commit/92c16d4dcbdc0401d8710dce1019dbf0dfde18f7) without any issues.