### PR TITLE
[feature] Emacs 29.x compatibility

### DIFF
--- a/tree-sitter-langs-build.el
+++ b/tree-sitter-langs-build.el
@@ -527,11 +527,13 @@ non-nil."
   "tree-sitter-langs-build releases grammars as LANG.so, but treesit needs libtree-sitter-LANG.so"
   (dolist (file (directory-files (tree-sitter-langs--bin-dir) 'full
                                  (concat "\\" (car tree-sitter-load-suffixes) "$")))
-    ;; make symlink libtree-sitter-c.so -> c.so
-    (make-symbolic-link file
-                        (concat (file-name-as-directory (file-name-directory file))
+    ;; make symlink (or copy) libtree-sitter-c.so -> c.so
+    (let ((target (concat (file-name-as-directory (file-name-directory file))
                                 "libtree-sitter-"
-                                (file-name-nondirectory file)))))
+                                (file-name-nondirectory file))))
+      (if (memq system-type '(ms-dos windows-nt cygwin))
+          (copy-file file target)
+        (make-symbolic-link file target)))))
 
 (defun tree-sitter-langs--copy-query (lang-symbol &optional force)
   "Copy highlights.scm file of LANG-SYMBOL to `tree-sitter-langs--queries-dir'.

--- a/tree-sitter-langs.el
+++ b/tree-sitter-langs.el
@@ -62,7 +62,10 @@
 (defvar tree-sitter-langs--testing)
 (eval-and-compile
   (unless (bound-and-true-p tree-sitter-langs--testing)
-    (tree-sitter-langs-install-grammars :skip-if-installed)))
+    (tree-sitter-langs-install-grammars :skip-if-installed))
+  (when (boundp treesit-extra-load-path)  ;; Emacs 29.x
+    (setq treesit-extra-load-path (append (list (tree-sitter-langs--bin-dir))
+                                          treesit-extra-load-path))))
 
 (defun tree-sitter-langs-ensure (lang-symbol)
   "Return the language object identified by LANG-SYMBOL.


### PR DESCRIPTION
A stab at #144.
- Make symlinks from `libtree-sitter-LANG.so` to `LANG.so` (or `libtree-sitter-LANG.dylib` to `LANG.dylib` on Darwin, etc) — Based on @ymarco's work in #99 
- Set up `treesit-extra-load-path` if that variable exists
