### PR TITLE
Update Rust grammar to support let-else syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Bump `rust` grammar
 
 ## 0.12.43 - 2023-09-04
 - Revert `Fortran` support

--- a/README.org
+++ b/README.org
@@ -53,6 +53,11 @@ To build all registered languages, and creating the bundle:
   script/compile all
 #+end_src
 
+To build on Apple Silicon:
+#+begin_src bash
+  script/compile rust -target aarch64-apple-darwin
+#+end_src
+
 *** Adding a new grammar
 - Register a new submodule. For example:
     #+begin_src bash


### PR DESCRIPTION
Update Rust grammar to support let-else syntax

https://github.com/tree-sitter/tree-sitter-rust/issues/160

Also added a note to the readme about how to run on Apple Silicon. I was confused that running compile didn't actually compile anything.