### PR TITLE
feat: Add Smithy support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -244,6 +244,12 @@
 	path = repos/scheme
 	url = https://github.com/6cdh/tree-sitter-scheme
 	branch = main
+[submodule "repos/smithy"]
+	path = repos/smithy
+	url = https://github.com/indoorvivants/tree-sitter-smithy
+	branch = main
+	update = none
+	ignore = dirty
 [submodule "repos/fennel"]
 	path = repos/fennel
 	url = https://github.com/TravonteD/tree-sitter-fennel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Add `Smithy` grammar
 
 ## 0.12.43 - 2023-09-04
 - Revert `Fortran` support

--- a/tree-sitter-langs.el
+++ b/tree-sitter-langs.el
@@ -156,6 +156,7 @@ See `tree-sitter-langs-repos'."
                 (rustic-mode     . rust)
                 (scala-mode      . scala)
                 (scheme-mode     . scheme)
+                (smithy-mode     . smithy)
                 (swift-mode      . swift)
                 (toml-mode       . toml)
                 (conf-toml-mode  . toml)


### PR DESCRIPTION
Following the [readme](https://github.com/emacs-tree-sitter/tree-sitter-langs#adding-a-new-grammar) and mirroring a similar PR (#165).

Compiled and tested against tree-sitter `0.19.5`.
Also tested locally, driving `tree-sitter-indent-mode`