### PR TITLE
Bump matlab grammar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Bump `MATLAB` grammar
+
 ## 0.12.21 - 2023-07-03
 
 - Add `MATLAB` grammar


### PR DESCRIPTION
Me again. The "fuzzer" found problems in the code that caused hangs and sigsegvs. They were related mostly to baddly handled UTF-8 chars in my code (and the sigsegv came from the stdlib O.o). Now fixed. It now ran for 1 hour without finding any more problems so hopefully there's nothing like that anymore.