### PR TITLE
add support for ocaml mli files

### DIFF
--- a/queries/ocaml-interface/highlights.scm
+++ b/queries/ocaml-interface/highlights.scm
@@ -1,0 +1,147 @@
+; Modules
+;--------
+
+[(module_name) (module_type_name)] @constructor
+
+; Types
+;------
+
+(
+  (type_constructor) @type.builtin
+  (#match? @type.builtin "^(int|char|bytes|string|float|bool|unit|exn|array|list|option|int32|int64|nativeint|format6|lazy_t)$")
+)
+
+[(class_name) (class_type_name) (type_constructor)] @type
+
+[(constructor_name) (tag)] @tag
+
+; Functions
+;----------
+
+(let_binding
+  pattern: (value_name) @function
+  (parameter))
+
+(let_binding
+  pattern: (value_name) @function
+  body: [(fun_expression) (function_expression)])
+
+(value_specification (value_name) @function)
+
+(external (value_name) @function)
+
+(method_name) @function.method
+
+; Application
+;------------
+
+(
+  (value_name) @function.builtin
+  (#match? @function.builtin "^(raise(_notrace)?|failwith|invalid_arg)$")
+)
+
+(infix_expression
+  left: (value_path (value_name) @function)
+  (infix_operator) @operator
+  (#eq? @operator "@@"))
+
+(infix_expression
+  (infix_operator) @operator
+  right: (value_path (value_name) @function)
+  (#eq? @operator "|>"))
+
+(application_expression
+  function: (value_path (value_name) @function))
+
+; Variables
+;----------
+
+[(value_name) (type_variable)] @variable
+
+(value_pattern) @variable.parameter
+
+; Properties
+;-----------
+
+[(label_name) (field_name) (instance_variable_name)] @property
+
+; Constants
+;----------
+
+(boolean) @constant
+
+[(number) (signed_number)] @number
+
+[(string) (character)] @string
+
+(quoted_string "{" @string "}" @string) @string
+
+(escape_sequence) @escape
+
+(conversion_specification) @string.special
+
+; Operators
+;----------
+
+(match_expression (match_operator) @keyword)
+
+(value_definition [(let_operator) (and_operator)] @keyword)
+
+[
+  (prefix_operator)
+  (sign_operator)
+  (infix_operator)
+  (hash_operator)
+  (indexing_operator)
+  (let_operator)
+  (and_operator)
+  (match_operator)
+] @operator
+
+(infix_operator ["&" "+" "-" "=" ">" "|" "%"] @operator)
+(signed_number ["+" "-"] @operator)
+
+["*" "#" "::" "<-"] @operator
+
+; Keywords
+;---------
+
+[
+  "and" "as" "assert" "begin" "class" "constraint" "do" "done" "downto" "else"
+  "end" "exception" "external" "for" "fun" "function" "functor" "if" "in"
+  "include" "inherit" "initializer" "lazy" "let" "match" "method" "module"
+  "mutable" "new" "nonrec" "object" "of" "open" "private" "rec" "sig" "struct"
+  "then" "to" "try" "type" "val" "virtual" "when" "while" "with"
+] @keyword
+
+; Punctuation
+;------------
+
+(attribute ["[@" "]"] @punctuation.special)
+(item_attribute ["[@@" "]"] @punctuation.special)
+(floating_attribute ["[@@@" "]"] @punctuation.special)
+(extension ["[%" "]"] @punctuation.special)
+(item_extension ["[%%" "]"] @punctuation.special)
+(quoted_extension ["{%" "}"] @punctuation.special)
+(quoted_item_extension ["{%%" "}"] @punctuation.special)
+
+"%" @punctuation.special
+
+["(" ")" "[" "]" "{" "}" "[|" "|]" "[<" "[>"] @punctuation.bracket
+
+(object_type ["<" ">"] @punctuation.bracket)
+
+[
+  "," "." ";" ":" "=" "|" "~" "?" "+" "-" "!" ">" "&"
+  "->" ";;" ":>" "+=" ":=" ".."
+] @punctuation.delimiter
+
+; Attributes
+;-----------
+
+(attribute_id) @attribute
+
+; Comments
+;---------
+
+[(comment) (line_number_directive) (directive) (shebang)] @comment


### PR DESCRIPTION
the ML and MLI files have separate parsers, but appear to share the same highlights.scm file. this change duplicates the file so that emacs can find the queries when using the ocaml-interface grammar. this is necessary to get proper highlighting in interface files. without it, tree-sitter-hl-mode will silently fail to activate in mli files if the language is set to ocaml-interface.

how an interface file looks with the ocaml parser:
<img width="412" alt="image" src="https://github.com/emacs-tree-sitter/tree-sitter-langs/assets/8755838/4c16b9c0-438b-4e63-97a0-3d8ac0f1b4f8">

how an interface file looks with the ocaml-interface parser
<img width="412" alt="image" src="https://github.com/emacs-tree-sitter/tree-sitter-langs/assets/8755838/61a2ecb7-d038-4c18-8581-05c933f5cbea">

some additional config is required on the part of the user to ensure that the ocaml-interface parser gets loaded for mli files. I use doom emacs so my configuration looks as follows

```emacs
(use-package! tuareg
  :init
  (define-derived-mode tuareg-mli-mode tuareg-mode "Tuareg Mli")
  (add-hook! 'tuareg-mli-mode-hook #'tree-sitter!)
  (setq auto-mode-alist (delete '("\\.ml[ip]?\\'" . tuareg-mode) auto-mode-alist))
  (add-to-list 'auto-mode-alist '("\\.ml[p]?\\'" . tuareg-mode))
  (add-to-list 'auto-mode-alist '("\\.mli\\'" . tuareg-mli-mode)))

(after! tree-sitter-langs
  (set-tree-sitter-lang! 'tuareg-mli-mode 'ocaml-interface))
```
 