### PR TITLE
fix(bibtex): add highlights.scm

### DIFF
--- a/queries/bibtex/highlights.scm
+++ b/queries/bibtex/highlights.scm
@@ -1,0 +1,47 @@
+[
+  (string_type)
+  (preamble_type)
+  (entry_type)
+] @keyword
+
+[
+  (junk)
+  (comment)
+] @comment
+
+[
+  "="
+  "#"
+] @operator
+
+(command) @function.builtin
+
+(number) @number
+
+(field
+  name: (identifier) @variable.builtin)
+
+(token
+  (identifier) @variable.parameter)
+
+[
+  (brace_word)
+  (quote_word)
+] @string
+
+[
+  (key_brace)
+  (key_paren)
+] @attribute
+
+(string
+  name: (identifier) @constant)
+
+[
+  "{"
+  "}"
+  "("
+  ")"
+] @punctuation.bracket
+
+"," @punctuation.delimiter


### PR DESCRIPTION
add missing highlights.scm for bibtex which is from [latex-lsp/tree-sitter-bibtex](https://github.com/latex-lsp/tree-sitter-bibtex).