### PR TITLE
Update tree-sitter-python repository to support Python 3.12

### DIFF
--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -155,7 +155,8 @@
  "with"
  "yield"
  "match"
- "case"] @keyword
+ "case"
+ "type"] @keyword
 
 ;; "Contexts" may have internal highlighting -> low priority.
 


### PR DESCRIPTION
* Updated tree-sitter-python to the newest version
* Added new keyword "type" to queries

