### PR TITLE
Rename 'LANG' variable in script/compile to avoid bug.

### DIFF
--- a/script/compile
+++ b/script/compile
@@ -16,7 +16,7 @@ set -euo pipefail
 here=$(cd "$(dirname "$BASH_SOURCE")"; pwd)
 PROJECT_ROOT=$(cd "$here/.."; pwd)
 
-LANG=$1
+PROGLANG=$1
 
 # Parse named parameters.
 POSITIONAL=()
@@ -39,7 +39,7 @@ if [ "$target" == "'" ]; then
     target=nil
 fi
 
-case $LANG in
+case $PROGLANG in
     (all)
         code="(tree-sitter-langs-create-bundle nil $target)"
         ;;
@@ -47,7 +47,7 @@ case $LANG in
         code="(tree-sitter-langs-compile-changed-or-all \"${POSITIONAL[1]:-origin/master}\" $target)"
         ;;
     (*)
-        code="(tree-sitter-langs-compile '$LANG nil $target)"
+        code="(tree-sitter-langs-compile '$PROGLANG nil ${target})"
 esac
 
 (


### PR DESCRIPTION
If 'LANG' is set to 'pascal' in script/compile, when `emacs -Q ...` is launcher emacs will exit with the following error:

    Language environment not defined: "Punjabi"

This is because 'LANG' is a locale setting variable so 'pascal' is interpreted as 'pa' which is code for the Punjabi locale.

fixes emacs-tree-sitter/tree-sitter-langs#283