### PR TITLE
Register language for typescript-tsx-mode

### DIFF
--- a/tree-sitter-langs.el
+++ b/tree-sitter-langs.el
@@ -199,6 +199,7 @@ See `tree-sitter-langs-repos'."
                 (tuareg-mode            . ocaml)
                 (twig-mode              . twig)
                 (typescript-mode        . typescript)
+                (typescript-tsx-mode    . tsx)
                 (typst-mode             . typst)
                 (verilog-mode           . verilog)
                 (vhdl-mode              . vhdl)


### PR DESCRIPTION
Highlights already existed, they were just never added for that major mode.