### PR TITLE
Add support for Android (with termux)

### DIFF
--- a/tree-sitter-langs-build.el
+++ b/tree-sitter-langs-build.el
@@ -244,6 +244,7 @@ infrequent (grammar-only changes).  It is different from the version of
   (pcase system-type
     ('darwin "macos")
     ('gnu/linux "linux")
+    ('android "linux")
     ('berkeley-unix "freebsd")
     ('windows-nt "windows")
     (_ (error "Unsupported system-type %s" system-type))))


### PR DESCRIPTION
This change allows the package to work on Emacs on Android + termux.

Users will still need to manually install the required termux packages.

A change to the `tree-sitter` package is also needed for things to work locally (see https://github.com/emacs-tree-sitter/elisp-tree-sitter/pull/280).