### PR TITLE
fix(python): properly highlight docstrings, f-strings, and escapes

### DIFF
--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -159,8 +159,6 @@
 
 ;; "Contexts" may have internal highlighting -> low priority.
 
-(comment) @comment
-(string) @string
 (escape_sequence) @escape
 
 (interpolation
@@ -168,7 +166,9 @@
  (_) @embedded
  "}" @punctuation.special)
 
+(comment) @comment
 ((string) @doc
  (.match? @doc "^(\"\"\"|r\"\"\")"))
+(string) @string
 
 (decorator) @function.special


### PR DESCRIPTION
This fixes python highlighting for docstrings, f-strings, and escape sequences.

## Before

![image](https://github.com/user-attachments/assets/37bf7dc5-4dba-4b08-9e13-703ba069a068)

## After

![image](https://github.com/user-attachments/assets/675df262-c9ee-4ed1-b6f0-3f1df078afba)


---

Closes #169