### PR TITLE
fix: update r queries

### DIFF
--- a/queries/r/highlights.scm
+++ b/queries/r/highlights.scm
@@ -1,106 +1,90 @@
 ; highlights.scm
 
-
 ; Literals
 
 (integer) @number
-
-(float) @float
-
+(float) @number
 (complex) @number
 
 (string) @string
-(string (escape_sequence) @string.escape)
+(string (string_content (escape_sequence) @string.escape))
+
+; Comments
 
 (comment) @comment
 
-;; tune for tree-sitter-langs as it make all as variable
-;; (identifier) @variable
-(left_assignment name: (identifier) @variable)
-(equals_assignment name: (identifier) @variable)
-(right_assignment name: (identifier) @variable)
-
-(formal_parameters (identifier) @parameter)
-(formal_parameters (default_parameter (identifier) @parameter))
-
 ; Operators
+
 [
- "="
- "<-"
- "<<-"
- "->>"
- "->"
+  "?" ":=" "=" "<-" "<<-" "->" "->>"
+  "~" "|>" "||" "|" "&&" "&"
+  "<" "<=" ">" ">=" "==" "!="
+  "+" "-" "*" "/" "::" ":::"
+  "**" "^" "$" "@" ":"
+  "special"
 ] @operator
 
-(unary operator: [
-  "-"
-  "+"
-  "!"
-  "~"
-] @operator)
-
-(binary operator: [
-  "-"
-  "+"
-  "*"
-  "/"
-  "^"
-  "<"
-  ">"
-  "<="
-  ">="
-  "=="
-  "!="
-  "||"
-  "|"
-  "&&"
-  "&"
-  ":"
-  "~"
-] @operator)
+; Punctuation
 
 [
-  "|>"
-  (special)
-] @operator
-
-(lambda_function "\\" @operator)
-
-[
- "("
- ")"
- "["
- "]"
- "{"
- "}"
+  "("  ")"
+  "{"  "}"
+  "["  "]"
+  "[[" "]]"
 ] @punctuation.bracket
 
-(dollar "$" @operator)
+(comma) @punctuation.delimiter
 
-(subset2
- [
-  "[["
-  "]]"
- ] @punctuation.bracket)
+; Variables
+
+(identifier) @variable
+
+; Functions
+
+(binary_operator
+    lhs: (identifier) @function
+    operator: "<-"
+    rhs: (function_definition)
+)
+
+(binary_operator
+    lhs: (identifier) @function
+    operator: "="
+    rhs: (function_definition)
+)
+
+; Calls
+
+(call function: (identifier) @function)
+
+; Parameters
+
+(parameters (parameter name: (identifier) @variable.parameter))
+(arguments (argument name: (identifier) @variable.parameter))
+
+; Namespace
+
+(namespace_operator lhs: (identifier) @namespace)
+
+(call
+    function: (namespace_operator rhs: (identifier) @function)
+)
+
+; Keywords
+
+(function_definition name: "function" @keyword.function)
+(function_definition name: "\\" @operator)
 
 [
- "in"
- (dots)
- (break)
- (next)
- (inf)
+  "in"
+  (return)
+  (next)
+  (break)
 ] @keyword
-
-[
-  (nan)
-  (na)
-  (null)
-] @type.builtin
 
 [
   "if"
   "else"
-  "switch"
 ] @conditional
 
 [
@@ -114,19 +98,15 @@
   (false)
 ] @boolean
 
-"function" @keyword.function
-
-(call function: (identifier) @function)
-(default_argument name: (identifier) @parameter)
-
-
-(namespace_get function: (identifier) @method)
-(namespace_get_internal function: (identifier) @method)
-
-(namespace_get namespace: (identifier) @namespace
- "::" @operator)
-(namespace_get_internal namespace: (identifier) @namespace
- ":::" @operator)
+[
+  (null)
+  (inf)
+  (nan)
+  (na)
+  (dots)
+  (dot_dot_i)
+] @constant.builtin
 
 ; Error
+
 (ERROR) @error

--- a/queries/r/locals.scm
+++ b/queries/r/locals.scm
@@ -2,10 +2,17 @@
 
 (function_definition) @local.scope
 
-(formal_parameters (identifier) @local.definition)
+(argument  name: (identifier) @local.definition)
+(parameter name: (identifier) @local.definition)
 
-(left_assignment name: (identifier) @local.definition)
-(equals_assignment name: (identifier) @local.definition)
-(right_assignment name: (identifier) @local.definition)
+(binary_operator
+    lhs: (identifier) @local.definition
+    operator: "<-")
+(binary_operator
+    lhs: (identifier) @local.definition
+    operator: "=")
+(binary_operator
+    operator: "->"
+    rhs: (identifier) @local.definition)
 
 (identifier) @local.reference

--- a/queries/r/tags.scm
+++ b/queries/r/tags.scm
@@ -1,0 +1,21 @@
+(binary_operator
+    lhs: (identifier) @name
+    operator: "<-"
+    rhs: (function_definition)
+) @definition.function
+
+(binary_operator
+    lhs: (identifier) @name
+    operator: "="
+    rhs: (function_definition)
+) @definition.function
+
+(call
+    function: (identifier) @name
+) @reference.call
+
+(call
+    function: (namespace_operator
+        rhs: (identifier) @name
+    )
+) @reference.call


### PR DESCRIPTION
This PR updates the R queries to be the same as those in r-lib/tree-sitter-r.

Note that I *think* the tuning done here:

https://github.com/emacs-tree-sitter/tree-sitter-langs/blob/7007cbcd5ab16d01aada410bfbe6ecc626ae838f/queries/r/highlights.scm#L17-L24


was accounted for in the latest queries, but I'm not positive.

Closes #735

