### PR TITLE
fix: R: Conform to Emacs highlighting conventions

### DIFF
--- a/queries/r/highlights.scm
+++ b/queries/r/highlights.scm
@@ -60,7 +60,17 @@
 
 ; Variables
 
-(identifier) @variable
+(binary_operator
+    lhs: (identifier) @variable
+    operator: "="
+    rhs: (_)
+)
+
+(binary_operator
+    lhs: (identifier) @variable
+    operator: "<-"
+    rhs: (_)
+)
 
 ; Namespace
 

--- a/queries/r/highlights.scm
+++ b/queries/r/highlights.scm
@@ -35,10 +35,6 @@
 
 (comma) @punctuation.delimiter
 
-; Variables
-
-(identifier) @variable
-
 ; Functions
 
 (binary_operator
@@ -61,6 +57,10 @@
 
 (parameters (parameter name: (identifier) @variable.parameter))
 (arguments (argument name: (identifier) @variable.parameter))
+
+; Variables
+
+(identifier) @variable
 
 ; Namespace
 


### PR DESCRIPTION
As per Emacs' highlighting conventions ([here](https://emacs-tree-sitter.github.io/syntax-highlighting/)), special faces should have higher priority than more general ones. This lowers the priority of the more general `variable` face. Additionally, it only highlights `variable` when assigned (with `<-` or `=`), and not otherwise.