### PR TITLE
Use yaml grammar from tree-sitter-grammars/tree-sitter-yaml

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -207,7 +207,7 @@
 	ignore = dirty
 [submodule "repos/yaml"]
 	path = repos/yaml
-	url = https://github.com/ikatyang/tree-sitter-yaml
+	url = https://github.com/tree-sitter-grammars/tree-sitter-yaml
 	branch = master
 	update = none
 	ignore = dirty


### PR DESCRIPTION
I found [this](https://github.com/tree-sitter-grammars/tree-sitter-yaml), a more recent and maintained version for the yaml language. It fixes a bug I encountered.

I encountered a bug in the current version from [ikatyang](https://github.com/ikatyang/tree-sitter-yaml), where if the yaml _key_ length is too long (more than 126 characters), the corresponding _value_ for the yaml entry is dropped from the parse tree.

How to reproduce the bug without emacs:
1. Visit https://ikatyang.github.io/tree-sitter-yaml/ (link provided in the [About section](https://github.com/ikatyang/tree-sitter-yaml))
2. Enter the following text: `a23456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456: sometext`
3. Observe that the tree is correct, with a _key_ and _value_ field.
4. Update the text to: `a234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567: sometext`. Note the extra 7 before the colon.
5. Observe that the tree is incorrect, where the _value_ field is missing.

This bug does not appear in [the new repository](https://github.com/tree-sitter-grammars/tree-sitter-yaml). I tested this locally in my emacs and the parsing works correctly.